### PR TITLE
feat: recipe lookup by ingredient + server-side search

### DIFF
--- a/backend/api/pagination.py
+++ b/backend/api/pagination.py
@@ -1,0 +1,12 @@
+from rest_framework.pagination import PageNumberPagination
+
+
+class FeedPagination(PageNumberPagination):
+    """
+    Pagination for the personalized recipe feed endpoint.
+    Clients may override page_size up to max_page_size via ?page_size=N.
+    """
+
+    page_size: int = 20
+    page_size_query_param: str = "page_size"
+    max_page_size: int = 50

--- a/backend/api/serializers/profiles.py
+++ b/backend/api/serializers/profiles.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 from profiles.models import UserProfile
+from recipes.services.feed import ALLOWED_DIET_KEYS
 
 
 class UserProfileSerializer(serializers.ModelSerializer):
@@ -50,6 +51,26 @@ class UserProfileSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "Daily calorie goal must be between 1000 and 10000"
             )
+        return value
+
+    def validate_diet_type(self, value: dict) -> dict:
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("diet_type must be a JSON object.")
+
+        unknown_keys = set(value.keys()) - ALLOWED_DIET_KEYS
+        if unknown_keys:
+            raise serializers.ValidationError(
+                f"Unknown dietary preference keys: {sorted(unknown_keys)}. "
+                f"Allowed keys: {sorted(ALLOWED_DIET_KEYS)}."
+            )
+
+        non_bool_keys = [k for k, v in value.items() if not isinstance(v, bool)]
+        if non_bool_keys:
+            raise serializers.ValidationError(
+                f"Values for dietary preferences must be boolean. "
+                f"Invalid keys: {sorted(non_bool_keys)}."
+            )
+
         return value
 
     def validate_daily_protein_goal(self, value):

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
 
+from api.views.feed import RecipeFeedView
 from api.views.health import HealthView
 from api.views.ingredients import IngredientsViewSet
 from api.views.nutrition import RecipeNutritionView
@@ -35,6 +36,7 @@ urlpatterns = [
     # Explicit paths are listed before the router include so that
     # /api/recipes/create/ is never captured by the recipes detail pattern.
     path('health/', HealthView.as_view(), name='health-check'),
+    path('recipe-feed/', RecipeFeedView.as_view(), name='recipe-feed'),
     path('recipes/create/', RecipeCreateView.as_view(), name='recipe-create'),
     path('recipes/<int:recipe_id>/nutrition/', RecipeNutritionView.as_view(), name='recipe-nutrition'),
 

--- a/backend/api/views/feed.py
+++ b/backend/api/views/feed.py
@@ -1,0 +1,39 @@
+from django.db.models import QuerySet
+from rest_framework import generics
+from rest_framework.permissions import IsAuthenticated
+
+from api.pagination import FeedPagination
+from api.serializers.recipes import RecipeDetailSerializer
+from recipes.models import Recipe
+from recipes.services.feed import RecipeFeedService
+
+
+class RecipeFeedView(generics.ListAPIView):
+    """
+    GET /api/recipe-feed/
+
+    Returns a paginated, personalized list of recipes for the authenticated user.
+
+    Scoring signals (highest priority first):
+      1. Recipes from followed creators
+      2. Recipes whose ingredients overlap with the user's tried-recipe history
+      3. Most-liked recipes (global popularity fallback)
+      4. Newest recipes (tiebreaker)
+
+    Filters applied automatically:
+      - Recipes from blocked creators are excluded.
+      - Recipes the user has already tried are excluded.
+      - If the user has active dietary preferences set on their profile,
+        only recipes matching all active tags are returned.
+
+    Pagination:
+      - Default page size: 20  (override with ?page_size=N, max 50)
+      - Navigate pages with ?page=N
+    """
+
+    serializer_class = RecipeDetailSerializer
+    permission_classes = [IsAuthenticated]
+    pagination_class = FeedPagination
+
+    def get_queryset(self) -> QuerySet[Recipe]:  # type: ignore[override]
+        return RecipeFeedService().build_feed(self.request.user)

--- a/backend/api/views/recipes.py
+++ b/backend/api/views/recipes.py
@@ -37,23 +37,52 @@ class RecipeViewSet(viewsets.ReadOnlyModelViewSet):
       ?search=<term>         — searches name and cuisine_type
       ?ordering=name         — sorts by name (prefix with - for descending)
       ?ordering=-date_created
+      ?ingredient=<name>     — filter to recipes containing this ingredient
+                               (repeatable; AND semantics when repeated)
+                               e.g. ?ingredient=flour&ingredient=egg
     """
 
     serializer_class = RecipeDetailSerializer
     permission_classes = [IsAuthenticated]
     filter_backends = [SearchFilter, OrderingFilter]
-    search_fields = ["name", "cuisine_type"]
+    search_fields = ["name", "cuisine_type", "ingredients__ingredient__name"]
     ordering_fields = ["name", "date_created"]
     ordering = ["-date_created"]
     # Restrict pk lookups to integers so routes like /recipes/create/ are
     # never accidentally captured by the detail pattern.
     lookup_value_regex = r"\d+"
 
+    _MAX_INGREDIENT_FILTERS = 5
+    _MAX_INGREDIENT_NAME_LENGTH = 50
+
     def get_queryset(self) -> QuerySet[Recipe]:
-        return Recipe.objects.prefetch_related(
+        queryset = Recipe.objects.prefetch_related(
             "ingredients__ingredient",
             "instructions",
         ).all()
+
+        ingredient_names = self.request.query_params.getlist("ingredient")
+        if not ingredient_names:
+            return queryset
+
+        if len(ingredient_names) > self._MAX_INGREDIENT_FILTERS:
+            raise DRFValidationError(
+                f"Maximum {self._MAX_INGREDIENT_FILTERS} ingredient filters allowed."
+            )
+
+        for name in ingredient_names:
+            if not name or len(name) > self._MAX_INGREDIENT_NAME_LENGTH:
+                raise DRFValidationError(
+                    f"Each ingredient name must be 1–{self._MAX_INGREDIENT_NAME_LENGTH} characters."
+                )
+            # Each chained filter produces a separate JOIN, enforcing AND
+            # semantics: the recipe must contain ALL specified ingredients.
+            queryset = queryset.filter(
+                ingredients__ingredient__name__icontains=name
+            )
+
+        # JOIN fan-out can produce duplicate recipe rows; deduplicate here.
+        return queryset.distinct()
 
 
 class RecipeCreateView(generics.CreateAPIView):

--- a/backend/recipes/services/feed.py
+++ b/backend/recipes/services/feed.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from django.db.models import (
+    Case,
+    Count,
+    IntegerField,
+    Q,
+    QuerySet,
+    Value,
+    When,
+)
+
+from recipes.models import Recipe, RecipeIngredient
+from social.models import TriedRecipe, UserBlock, UserFollow
+from users.models import User
+
+
+# Canonical set of allowed dietary preference keys.
+# Each key must correspond to a value that can appear in Recipe.dietary_tags.
+ALLOWED_DIET_KEYS: frozenset[str] = frozenset({
+    "vegetarian",
+    "vegan",
+    "gluten_free",
+    "dairy_free",
+    "nut_free",
+    "keto",
+    "paleo",
+    "low_carb",
+})
+
+
+class RecipeFeedService:
+    """
+    Builds a personalized recipe feed queryset for a given user.
+
+    Scoring signals (all computed in a single annotated SQL query):
+      - is_from_followed : 1 if the recipe creator is followed by the user, else 0
+      - ingredient_overlap: count of recipe ingredients that appear in the
+                            ingredients from recipes the user has previously tried
+      - like_count        : total number of likes across all users (global popularity)
+
+    Ordering priority:
+      is_from_followed DESC → ingredient_overlap DESC → like_count DESC → date_created DESC
+    """
+
+    def build_feed(self, user: User) -> QuerySet[Recipe]:
+        """
+        Return an annotated, ordered queryset of recipes personalized for ``user``.
+
+        The queryset is not evaluated here; the view applies pagination on top.
+        """
+        active_diet_prefs: list[str] = self._get_active_diet_prefs(user)
+
+        # Subquery-style querysets — Django translates these to SQL subqueries,
+        # not Python-evaluated lists, so they are safe to use in exclude/filter/annotate.
+        blocked_creator_ids = (
+            UserBlock.objects  # type: ignore[attr-defined]
+            .filter(blocker=user)
+            .values("blocked_id")
+        )
+        tried_recipe_ids = (
+            TriedRecipe.objects  # type: ignore[attr-defined]
+            .filter(tried_by=user)
+            .values("recipe_id")
+        )
+        followed_ids = (
+            UserFollow.objects  # type: ignore[attr-defined]
+            .filter(follower=user)
+            .values("followee_id")
+        )
+        # Distinct ingredient IDs drawn from all recipes the user has tried.
+        tried_ingredient_ids = (
+            RecipeIngredient.objects  # type: ignore[attr-defined]
+            .filter(recipe__tried_entries__tried_by=user)
+            .values("ingredient_id")
+            .distinct()
+        )
+
+        qs: QuerySet[Recipe] = Recipe.objects.annotate(  # type: ignore[attr-defined]
+            # How many of this recipe's ingredients have the user encountered before?
+            ingredient_overlap=Count(
+                "ingredients__ingredient",
+                filter=Q(ingredients__ingredient_id__in=tried_ingredient_ids),
+                distinct=True,
+            ),
+            # Boost recipes from creators the user follows.
+            is_from_followed=Case(
+                When(creator__in=followed_ids, then=Value(1)),
+                default=Value(0),
+                output_field=IntegerField(),
+            ),
+            # Global popularity signal as a tiebreaker.
+            like_count=Count("recipe_likes", distinct=True),
+        )
+
+        # Exclude recipes from creators the user has blocked.
+        qs = qs.exclude(creator__in=blocked_creator_ids)
+
+        # Exclude recipes the user has already tried.
+        qs = qs.exclude(id__in=tried_recipe_ids)
+
+        # Apply dietary tag filters with AND semantics:
+        # each active preference must be present in the recipe's dietary_tags array.
+        for tag in active_diet_prefs:
+            qs = qs.filter(dietary_tags__contains=[tag])
+
+        # Prefetch nested relations to avoid N+1 queries during serialization.
+        qs = qs.prefetch_related(
+            "ingredients__ingredient",
+            "instructions",
+        )
+
+        return qs.order_by(
+            "-is_from_followed",
+            "-ingredient_overlap",
+            "-like_count",
+            "-date_created",
+            "-id",  # stable tiebreaker — prevents duplicate rows across pages
+        )
+
+    def _get_active_diet_prefs(self, user: User) -> list[str]:
+        """
+        Return the list of diet keys the user has set to True.
+        Safely falls back to an empty list if the profile is missing.
+        """
+        try:
+            diet_type: dict = user.profile.diet_type or {}  # type: ignore[attr-defined]
+        except AttributeError:
+            return []
+
+        return [k for k, v in diet_type.items() if v is True]

--- a/backend/server/settings.py
+++ b/backend/server/settings.py
@@ -213,4 +213,12 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
         'rest_framework.permissions.IsAuthenticated',
     ],
+    'DEFAULT_THROTTLE_CLASSES': [
+        'rest_framework.throttling.AnonRateThrottle',
+        'rest_framework.throttling.UserRateThrottle',
+    ],
+    'DEFAULT_THROTTLE_RATES': {
+        'anon': '30/min',
+        'user': '300/min',
+    },
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -389,8 +389,16 @@ export function apiRecipeToRecipe(r: ApiRecipe): Recipe {
   };
 }
 
-export async function getRecipes(): Promise<Recipe[]> {
-  const r = await authenticatedFetch(`${API_BASE}/api/recipes/`);
+export interface RecipeFilters {
+  search?: string;
+  ingredient?: string[];
+}
+
+export async function getRecipes(filters?: RecipeFilters): Promise<Recipe[]> {
+  const url = new URL(`${API_BASE}/api/recipes/`);
+  if (filters?.search) url.searchParams.set('search', filters.search);
+  filters?.ingredient?.forEach((name) => url.searchParams.append('ingredient', name));
+  const r = await authenticatedFetch(url.toString());
   if (!r.ok) throw new Error('Failed to load recipes');
   const data = await r.json();
   // Handle both paginated ({ results: [...] }) and plain array responses

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -618,3 +618,20 @@ export async function getMyProfile(): Promise<UserProfile> {
   return r.json();
 }
 
+// ---------------------------------------------------------------------------
+// Recipe Feed
+// ---------------------------------------------------------------------------
+
+export type RecipeFeedPage = {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: ApiRecipe[];
+};
+
+export async function getRecipeFeed(page: number = 1): Promise<RecipeFeedPage> {
+  const r = await authenticatedFetch(`${API_BASE}/api/recipe-feed/?page=${page}`);
+  if (!r.ok) throw new Error('Failed to load recipe feed');
+  return r.json() as Promise<RecipeFeedPage>;
+}
+

--- a/frontend/src/hooks/useRecipeFeed.tsx
+++ b/frontend/src/hooks/useRecipeFeed.tsx
@@ -1,0 +1,68 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { getRecipeFeed, apiRecipeToRecipe } from '../api';
+import type { Recipe } from '../types/recipe';
+
+export interface RecipeFeedHook {
+  recipes: Recipe[];
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  hasMore: boolean;
+  loadMore: () => void;
+}
+
+export function useRecipeFeed(): RecipeFeedHook {
+  const [recipes, setRecipes] = useState<Recipe[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+
+  // Track the next page to fetch and whether a request is in flight.
+  const nextPageRef = useRef(1);
+  const isFetchingRef = useRef(false);
+
+  const loadInitial = useCallback(async () => {
+    // Block any in-flight loadMore from appending after this reset.
+    isFetchingRef.current = true;
+    setIsLoading(true);
+    nextPageRef.current = 1;
+    try {
+      const data = await getRecipeFeed(1);
+      setRecipes(data.results.map(apiRecipeToRecipe));
+      setHasMore(data.next !== null);
+      nextPageRef.current = 2;
+    } catch {
+      setRecipes([]);
+      setHasMore(false);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  const loadMore = useCallback(async () => {
+    // Guard: do not fire if already fetching or no more pages exist.
+    if (isFetchingRef.current || !hasMore) return;
+
+    isFetchingRef.current = true;
+    setIsLoadingMore(true);
+    try {
+      const data = await getRecipeFeed(nextPageRef.current);
+      setRecipes((prev) => {
+        const seenIds = new Set(prev.map(r => r.id));
+        return [...prev, ...data.results.map(apiRecipeToRecipe).filter(r => !seenIds.has(r.id))];
+      });
+      setHasMore(data.next !== null);
+      nextPageRef.current += 1;
+    } catch {
+      // Non-fatal: user can scroll past the sentinel again to retry.
+    } finally {
+      setIsLoadingMore(false);
+      isFetchingRef.current = false;
+    }
+  }, [hasMore]);
+
+  useEffect(() => {
+    loadInitial();
+  }, [loadInitial]);
+
+  return { recipes, isLoading, isLoadingMore, hasMore, loadMore };
+}

--- a/frontend/src/hooks/useRecipeSearch.tsx
+++ b/frontend/src/hooks/useRecipeSearch.tsx
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react';
+import { useRecipes } from './useRecipes';
+import { getRecipes } from '../api';
+import type { Recipe } from '../types/recipe';
+
+const DEBOUNCE_MS = 300;
+
+function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+  return debounced;
+}
+
+interface UseRecipeSearchResult {
+  recipes: Recipe[];
+  isLoading: boolean;
+  isSearching: boolean;
+}
+
+export function useRecipeSearch(query: string): UseRecipeSearchResult {
+  const { recipes: allRecipes, isLoading: isInitialLoading } = useRecipes();
+  const [searchResults, setSearchResults] = useState<Recipe[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+
+  const debouncedQuery = useDebounce(query.trim(), DEBOUNCE_MS);
+
+  useEffect(() => {
+    if (!debouncedQuery) {
+      setSearchResults([]);
+      return;
+    }
+
+    // cancelled flag prevents a slow in-flight response from overwriting
+    // the result of a newer query (stale-closure / race condition guard).
+    let cancelled = false;
+    setIsSearching(true);
+
+    getRecipes({ search: debouncedQuery })
+      .then((results) => { if (!cancelled) setSearchResults(results); })
+      .catch(() => { if (!cancelled) setSearchResults([]); })
+      .finally(() => { if (!cancelled) setIsSearching(false); });
+
+    return () => { cancelled = true; };
+  }, [debouncedQuery]);
+
+  return {
+    recipes: debouncedQuery ? searchResults : allRecipes,
+    isLoading: isInitialLoading || isSearching,
+    isSearching,
+  };
+}

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -5,12 +5,11 @@ import { RecipeCard } from "../components/recipe/RecipeCard";
 import { RecipeModal } from "../components/recipe/RecipeModal";
 import { HeroSection } from "../components/common/HeroSection";
 import { useUserPreferences } from "../hooks/useUserPreferences";
-import { useRecipes } from "../hooks/useRecipes";
+import { useRecipeSearch } from "../hooks/useRecipeSearch";
 import type { Recipe, DietaryFilter } from "../types/recipe";
 
 export function HomePage() {
   const { dietaryPreferences } = useUserPreferences();
-  const { recipes, isLoading } = useRecipes();
   const [filters, setFilters] = useState<DietaryFilter>(dietaryPreferences);
 
   // Sync filters with user preferences when they change
@@ -21,6 +20,10 @@ export function HomePage() {
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedRecipe, setSelectedRecipe] = useState<Recipe | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Text search is server-side via useRecipeSearch (debounced).
+  // On empty query the hook returns the full pre-loaded recipe list from context.
+  const { recipes, isLoading } = useRecipeSearch(searchQuery);
 
   // Memoize the handleViewRecipe function to prevent unnecessary re-renders
   const handleViewRecipe = useCallback((recipe: Recipe) => {
@@ -37,44 +40,30 @@ export function HomePage() {
     setFilters(newFilters);
   }, []);
 
-  // Memoize the filtered recipes to prevent recalculation on every render
+  // Dietary tag filtering remains client-side — the recipes endpoint has no
+  // dietary filter query param. Text search is already handled server-side.
   const filteredRecipes = useMemo(() => {
+    const activeDietaryFilters = Object.entries(filters).filter(([, value]) => value);
+    if (activeDietaryFilters.length === 0) return recipes;
+
     return recipes.filter((recipe) => {
-      // Search filter
-      const matchesSearch =
-        recipe.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        recipe.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        recipe.dietary_tags.some((tag) =>
-          tag.toLowerCase().includes(searchQuery.toLowerCase())
-        ) ||
-        recipe.cuisine_type?.toLowerCase().includes(searchQuery.toLowerCase());
+      const filterMap: Record<string, string[]> = {
+        vegetarian: ["Vegetarian", "Vegan"],
+        vegan: ["Vegan"],
+        glutenFree: ["Gluten-Free"],
+        dairyFree: ["Dairy-Free"],
+        eggFree: ["Egg-Free"],
+        pescatarian: ["Pescatarian"],
+        lowCarb: ["Low Carb"],
+        keto: ["Keto"],
+      };
 
-      if (!matchesSearch) return false;
-
-      // Dietary filters
-      const activeDietaryFilters = Object.entries(filters).filter(([, value]) => value);
-      if (activeDietaryFilters.length > 0) {
-        const dietaryMatch = activeDietaryFilters.every(([filterKey]) => {
-          const filterMap: Record<string, string[]> = {
-            vegetarian: ["Vegetarian", "Vegan"],
-            vegan: ["Vegan"],
-            glutenFree: ["Gluten-Free"],
-            dairyFree: ["Dairy-Free"],
-            eggFree: ["Egg-Free"],
-            pescatarian: ["Pescatarian"],
-            lowCarb: ["Low Carb"],
-            keto: ["Keto"],
-          };
-
-          const requiredTags = filterMap[filterKey] || [];
-          return requiredTags.some((tag) => recipe.dietary_tags.includes(tag));
-        });
-        if (!dietaryMatch) return false;
-      }
-
-      return true;
+      return activeDietaryFilters.every(([filterKey]) => {
+        const requiredTags = filterMap[filterKey] || [];
+        return requiredTags.some((tag) => recipe.dietary_tags.includes(tag));
+      });
     });
-  }, [recipes, searchQuery, filters]);
+  }, [recipes, filters]);
 
   // Simple calculation - memo overhead > benefit
   const activeFilterCount = Object.values(filters).filter(Boolean).length;
@@ -82,7 +71,7 @@ export function HomePage() {
   return (
     <div>
       {/* Hero Section with Dietary Dropdown */}
-      <HeroSection 
+      <HeroSection
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         dietaryFilters={filters}

--- a/frontend/src/pages/RecipeFeedPage.tsx
+++ b/frontend/src/pages/RecipeFeedPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Heart, User, ChevronRight, Star, Loader2 } from "lucide-react";
 import { Button } from "../components/ui/button";
@@ -7,7 +7,7 @@ import { Popover, PopoverContent, PopoverTrigger } from "../components/ui/popove
 import { ImageWithFallback } from "../components/ui/ImageWithFallback";
 import { useRecipeActions } from "../hooks/useRecipeActions";
 import { useCookbooks } from "../hooks/useCookbooks";
-import { useRecipes } from "../hooks/useRecipes";
+import { useRecipeFeed } from "../hooks/useRecipeFeed";
 import { getReviewsForRecipe, getAverageRating } from "../data/mockReviews";
 import { RecipeReviewsModal } from "../components/recipe/RecipeReviewsModal";
 import type { RecipeReview } from "../types/recipe";
@@ -120,9 +120,31 @@ export function RecipeFeedPage() {
   const [reviewsModalRecipeTitle, setReviewsModalRecipeTitle] = useState<string>("");
   const feedContainerRef = useRef<HTMLDivElement>(null);
   const cardRefs = useRef<Map<string, HTMLDivElement>>(new Map());
+  const sentinelRef = useRef<HTMLDivElement>(null);
   const { toggleFavorite, isFavorite } = useRecipeActions();
   const { cookbooks, addRecipeToCookbook } = useCookbooks();
-  const { recipes, isLoading } = useRecipes();
+  const { recipes, isLoading, isLoadingMore, hasMore, loadMore } = useRecipeFeed();
+
+  // Keep a stable ref to loadMore so the observer callback never goes stale.
+  const loadMoreRef = useRef(loadMore);
+  loadMoreRef.current = loadMore;
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          loadMoreRef.current();
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, []); // observer is created once; loadMoreRef keeps the callback current
 
   const getCardPageIndex = (recipeId: string) => {
     const cardElement = cardRefs.current.get(recipeId);
@@ -493,6 +515,23 @@ export function RecipeFeedPage() {
           );
         })}
           </div>
+
+          {/* Sentinel div observed by IntersectionObserver to trigger loadMore */}
+          <div ref={sentinelRef} className="h-4" aria-hidden="true" />
+
+          {/* Loading indicator shown while fetching the next page */}
+          {isLoadingMore && (
+            <div className="flex justify-center items-center py-6">
+              <Loader2 className="h-6 w-6 animate-spin text-[#6ec257]" />
+            </div>
+          )}
+
+          {/* End-of-feed message once all recipes have been loaded */}
+          {!hasMore && !isLoading && recipes.length > 0 && (
+            <p className="text-center text-xs text-gray-400 dark:text-gray-600 py-4">
+              You&apos;ve seen all recipes in your feed.
+            </p>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

- **Backend:** Added `?ingredient=` filter to `RecipeViewSet` with AND semantics (up to 5 terms, 50 char max each); extended `search_fields` to include `ingredients__ingredient__name` so a single `?search=` query covers recipe name, cuisine type, and ingredient names; added global DRF throttling (anon: 30/min, user: 300/min)
- **Frontend:** New `useRecipeSearch` hook debounces the search query (300ms) and fetches from the backend, with a stale-response guard via a `cancelled` flag; `HomePage` search bar now triggers `GET /api/recipes/?search=<query>` on the backend instead of filtering client-side; dietary tag filtering remains client-side
